### PR TITLE
Update Amplitude javascript sdk to v2.3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.2.1-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.3.0-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.
@@ -30,6 +30,9 @@ var Amplitude = module.exports = integration('Amplitude')
   .option('trackCategorizedPages', true)
   .option('trackUtmProperties', true)
   .option('trackReferrer', false)
+  .option('batchEvents', false)
+  .option('eventUploadThreshold', 30)
+  .option('eventUploadPeriodMillis', 30000)
   .tag('<script src="' + src + '">');
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,7 +34,10 @@ describe('Amplitude', function() {
       .option('trackAllPages', false)
       .option('trackUtmProperties', true)
       .option('trackNamedPages', true)
-      .option('trackReferrer', false));
+      .option('trackReferrer', false)
+      .option('batchEvents', false)
+      .option('eventUploadThreshold', 30)
+      .option('eventUploadPeriodMillis', 30000));
   });
 
   describe('before loading', function() {


### PR DESCRIPTION
This update brings event-batching functionality (that already exists in our Android and iOS SDKs). By default batchEvents is disabled, and events are sent immediately after they are logged. But when batchEvents is enabled, then events are only sent when the number of events is at least `eventUploadThreshold` (default 30), or after `eventUploadPeriodMillis` (default 30,000) milliseconds has passed, whichever comes first.

3 options to expose:

```
"batchEvents": {
      "default": false,
      "description": "If true, events are batched together and uploaded only when the number of unsent events is greater than or equal to `eventUploadThreshold` or after `eventUploadPeriodMillis` milliseconds have passed since the first unsent event was logged.",
      "label": "Batch Events",
      "type": "boolean"
}

"eventUploadThreshold": {
      "default": 30,
      "description": "Minimum number of events to batch together per request if `batchEvents` is `true`.",
      "label": "Event Upload Threshold (for batching events)",
      "type": "integer"
}

"eventUploadPeriodMillis": {
      "default": 30000,
      "description": "Amount of time in milliseconds that the SDK waits before uploading events if `batchEvents` is `true`.",
      "label": "Event Upload Period Millis (for batching events)",
      "type": "long"
}
```

https://github.com/amplitude/Amplitude-Javascript#configuration-options
