### PR TITLE
updating Amplitude SDK to v2.5.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.4.1-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.5.0-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.
@@ -45,7 +45,7 @@ var Amplitude = module.exports = integration('Amplitude')
 
 Amplitude.prototype.initialize = function() {
   /* eslint-disable */
-  (function(e,t){var r=e.amplitude||{};r._q=[];function a(e){r[e]=function(){r._q.push([e].concat(Array.prototype.slice.call(arguments,0)))}}var i=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties"];for(var o=0;o<i.length;o++){a(i[o])}e.amplitude=r})(window,document);
+  (function(t,e){var n=t.amplitude||{};var r=function(){this._q=[];return this};function s(t){r.prototype[t]=function(){this._q.push([t].concat(Array.prototype.slice.call(arguments,0)));return this}}var i=["add","set","setOnce","unset"];for(var o=0;o<i.length;o++){s(i[o]);}n.Identify=r;n._q=[];function a(t){n[t]=function(){n._q.push([t].concat(Array.prototype.slice.call(arguments,0)));}}var u=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties","identify"];for(var c=0;c<u.length;c++){a(u[c])}t.amplitude=n})(window,document);
   /* eslint-enable */
 
   this.setDomain(window.location.href);
@@ -58,12 +58,14 @@ Amplitude.prototype.initialize = function() {
   if (umd) {
     window.require([src], function(amplitude) {
       window.amplitude = amplitude;
+      window.amplitude.runQueuedFunctions();
       self.ready();
     });
     return;
   }
 
   this.load(function() {
+    window.amplitude.runQueuedFunctions();
     self.ready();
   });
 };


### PR DESCRIPTION
A bug fix and added support for user property operations: https://github.com/amplitude/Amplitude-Javascript/releases/tag/v2.5.0

The underlying implementation of setUserProperties now uses our identify api, but the Segment Identify call should still work as intended
