### PR TITLE
updating Amplitude SDK v2.6.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.6.0-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.6.1-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.


### PR DESCRIPTION
The most recent update 2.6.0 breaks some functionality. We need to patch and release as soon as possible. Thanks!
