### PR TITLE
Updating Amplitude SDK v2.7.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.6.1-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.7.0-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.


### PR DESCRIPTION
This update will migrate sessionId and eventId to cookies so that sessions persist across different subdomains.
