### PR TITLE
Only runQueuedFunctions after SDK loads

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,8 +6,10 @@
   "license": "MIT",
   "main": "lib/index.js",
   "dependencies": {
+    "component/bind": "1.0.0",
     "segmentio/analytics.js-integration": "^1.0.0",
-    "segmentio/top-domain": "1.0.0"
+    "segmentio/top-domain": "1.0.0",
+    "segmentio/when": "0.0.1"
   },
   "development": {
     "segmentio/analytics.js-core": "^2.10.0",

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,10 @@
  * Module dependencies.
  */
 
+var bind = require('bind');
 var integration = require('analytics.js-integration');
 var topDomain = require('top-domain');
+var when = require('when');
 
 /**
  * UMD?
@@ -54,19 +56,25 @@ Amplitude.prototype.initialize = function() {
     includeReferrer: this.options.trackReferrer
   });
 
-  var self = this;
+  var loaded = bind(this, this.loaded);
+  var ready = this.ready;
+
   if (umd) {
     window.require([src], function(amplitude) {
       window.amplitude = amplitude;
-      window.amplitude.runQueuedFunctions();
-      self.ready();
+      when(loaded, function() {
+        window.amplitude.runQueuedFunctions();
+        ready();
+      });
     });
     return;
   }
 
   this.load(function() {
-    window.amplitude.runQueuedFunctions();
-    self.ready();
+    when(loaded, function() {
+      window.amplitude.runQueuedFunctions();
+      ready();
+    });
   });
 };
 


### PR DESCRIPTION
There was a bug where runQueuedFunctions was being called before the SDK had finished loading, causing script errors.

This patch was suggested by @ndhoule during this discussion: https://github.com/segment-integrations/analytics.js-integration-amplitude/commit/74ca59fb94f3dfef289c27ab1dc46a9c237e74f8#commitcomment-15323489

@ndhoule is this the correct fix? I ran Segment's tests and they seem to pass.
