### PR TITLE
update Amplitude v2.9.1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.9.0-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.9.1-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.
@@ -47,7 +47,7 @@ var Amplitude = module.exports = integration('Amplitude')
 
 Amplitude.prototype.initialize = function() {
   /* eslint-disable */
-  (function(e,t){var r=e.amplitude||{};var n=function(){this._q=[];return this};function s(e){n.prototype[e]=function(){this._q.push([e].concat(Array.prototype.slice.call(arguments,0)));return this}}var i=["add","append","clearAll","set","setOnce","unset"];for(var o=0;o<i.length;o++){s(i[o])}r.Identify=n;r._q=[];function a(e){r[e]=function(){r._q.push([e].concat(Array.prototype.slice.call(arguments,0)));}}var c=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties","identify","clearUserProperties"];for(var l=0;l<c.length;l++){a(c[l])}e.amplitude=r})(window,document);
+  (function(e,t){var r=e.amplitude||{};var n=function(){this._q=[];return this};function i(e){n.prototype[e]=function(){this._q.push([e].concat(Array.prototype.slice.call(arguments,0)));return this}}var o=["add","append","clearAll","set","setOnce","unset"];for(var s=0;s<o.length;s++){i(o[s])}r.Identify=n;r._q=[];function a(e){r[e]=function(){r._q.push([e].concat(Array.prototype.slice.call(arguments,0)));}}var c=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties","identify","clearUserProperties"];for(var l=0;l<c.length;l++){a(c[l])}e.amplitude=r})(window,document);
   /* eslint-enable */
 
   this.setDomain(window.location.href);


### PR DESCRIPTION
Some minor bug fixes and convenience methods. See [release notes](https://github.com/amplitude/Amplitude-Javascript/releases/tag/v2.9.1) for more.
