### PR TITLE
update amplitude JS SDK v3.0.2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.12.1-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-3.0.2-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.
@@ -36,6 +36,7 @@ var Amplitude = module.exports = integration('Amplitude')
   .option('batchEvents', false)
   .option('eventUploadThreshold', 30)
   .option('eventUploadPeriodMillis', 30000)
+  .option('useLogRevenueV2', false)
   .tag('<script src="' + src + '">');
 
 /**
@@ -146,13 +147,35 @@ Amplitude.prototype.identify = function(identify) {
 Amplitude.prototype.track = function(track) {
   var props = track.properties();
   var event = track.event();
-  var revenue = track.revenue();
 
   // track the event
   window.amplitude.logEvent(event, props);
 
   // also track revenue
-  if (revenue) {
+  var revenue = track.revenue();
+  if (this.options.useLogRevenueV2) {
+    var price = props.price;
+    var quantity = props.quantity;
+    if (!price && !revenue) {
+      return;
+    }
+
+    // if no price, fallback to using revenue
+    if (!price) {
+      price = revenue;
+      quantity = 1;
+    }
+
+    var ampRevenue = new window.amplitude.Revenue().setPrice(price).setQuantity(quantity);
+    if (props.productId) {
+      ampRevenue.setProductId(props.productId);
+    }
+    if (props.revenueType) {
+      ampRevenue.setRevenueType(props.revenueType);
+    }
+    ampRevenue.setEventProperties(props);
+    window.amplitude.logRevenueV2(ampRevenue);
+  } else if (revenue) {
     window.amplitude.logRevenue(revenue, props.quantity, props.productId);
   }
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -119,7 +119,7 @@ describe('Amplitude', function() {
           analytics.spy(window.amplitude, '_initUtmData');
           analytics.called(window.amplitude._initUtmData);
         });
-      }); 
+      });
 
       it('should not track utm properties if disabled', function() {
         analytics.spy(window.amplitude, '_initUtmData');
@@ -193,28 +193,60 @@ describe('Amplitude', function() {
       beforeEach(function() {
         analytics.stub(window.amplitude, 'logEvent');
         analytics.stub(window.amplitude, 'logRevenue');
+        analytics.stub(window.amplitude, 'logRevenueV2');
       });
 
       it('should send an event', function() {
         analytics.track('event');
         analytics.called(window.amplitude.logEvent, 'event');
         analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
       });
 
       it('should send an event and properties', function() {
         analytics.track('event', { property: true });
         analytics.called(window.amplitude.logEvent, 'event', { property: true });
         analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
       });
 
       it('should send a revenue event', function() {
         analytics.track('event', { revenue: 19.99 });
         analytics.called(window.amplitude.logRevenue, 19.99, undefined, undefined);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
       });
 
       it('should send a revenue event with quantity and productId', function() {
         analytics.track('event', { revenue: 19.99, quantity: 2, productId: 'AMP1' });
         analytics.called(window.amplitude.logRevenue, 19.99, 2, 'AMP1');
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should send a revenueV2 event', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        analytics.track('event', { revenue: 19.99 });
+        var ampRevenue = new window.amplitude.Revenue().setPrice(19.99).setEventProperties({ revenue: 19.99 });
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
+      });
+
+      it('should send a revenueV2 event with quantity and productId and revenueType', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        var props = { revenue: 20.00, quantity: 2, price: 10.00, productId: 'AMP1', revenueType: 'purchase' };
+        analytics.track('event', props);
+        var ampRevenue = new window.amplitude.Revenue().setPrice(10.00).setQuantity(2).setProductId('AMP1');
+        ampRevenue.setRevenueType('purchase').setEventProperties(props);
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
+      });
+
+      it('should send a revenueV2 event with revenue if missing price', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        analytics.track('event', { revenue: 20.00, quantity: 2, productId: 'AMP1' });
+        var ampRevenue = new window.amplitude.Revenue().setPrice(20.00).setProductId('AMP1');
+        ampRevenue.setEventProperties({ revenue: 20.00, quantity: 2, productId: 'AMP1' });
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
       });
     });
 


### PR DESCRIPTION
Updating Amplitude to v3.0.2. Updating to our new logRevenueV2 method to handle revenue. This allows people to also set a revenueType field, as well as capture event properties with the revenue event.

This is potentially api-breaking due to a mismatch between Segment's ecommerce API and our revenue API. Before this update, if the quantity was > 1, then we would actually multiply revenue \* quantity to get the final revenue. But now we recognize the top-level "revenue" field to be the entire amount of the revenue event (price \* quantity). We now also recognize top-level price and quantity fields. If those 2 are set, then we will take those over the revenue field (in theory revenue should = price \* quantity). If either one of those 2 fields are missing, then we just use the revenue as the price field with quantity = 1 (even if they define quantity > 1). With our new definitions it doesn't make sense to have a revenue and a quantity, but no price field.
