### PR TITLE
Only send revenue event if revenue is being tracked

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -153,30 +153,29 @@ Amplitude.prototype.track = function(track) {
 
   // also track revenue
   var revenue = track.revenue();
-  if (this.options.useLogRevenueV2) {
-    var price = props.price;
-    var quantity = props.quantity;
-    if (!price && !revenue) {
-      return;
-    }
+  if (revenue) {
+    // use logRevenueV2 with revenue props
+    if (this.options.useLogRevenueV2) {
+      var price = props.price;
+      var quantity = props.quantity;
+      if (!price) {
+        price = revenue;
+        quantity = 1;
+      }
 
-    // if no price, fallback to using revenue
-    if (!price) {
-      price = revenue;
-      quantity = 1;
+      var ampRevenue = new window.amplitude.Revenue().setPrice(price).setQuantity(quantity);
+      if (props.productId) {
+        ampRevenue.setProductId(props.productId);
+      }
+      if (props.revenueType) {
+        ampRevenue.setRevenueType(props.revenueType);
+      }
+      ampRevenue.setEventProperties(props);
+      window.amplitude.logRevenueV2(ampRevenue);
+    } else {
+      // fallback to logRevenue v1
+      window.amplitude.logRevenue(revenue, props.quantity, props.productId);
     }
-
-    var ampRevenue = new window.amplitude.Revenue().setPrice(price).setQuantity(quantity);
-    if (props.productId) {
-      ampRevenue.setProductId(props.productId);
-    }
-    if (props.revenueType) {
-      ampRevenue.setRevenueType(props.revenueType);
-    }
-    ampRevenue.setEventProperties(props);
-    window.amplitude.logRevenueV2(ampRevenue);
-  } else if (revenue) {
-    window.amplitude.logRevenue(revenue, props.quantity, props.productId);
   }
 };
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -248,6 +248,21 @@ describe('Amplitude', function() {
         analytics.didNotCall(window.amplitude.logRevenue);
         analytics.called(window.amplitude.logRevenueV2, ampRevenue);
       });
+
+      it('should only send a revenue event if revenue is being logged', function() {
+        analytics.track('event', { price: 10.00, quantity: 2, productId: 'AMP1' });
+        analytics.called(window.amplitude.logEvent);
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
+
+      it('should only send a revenueV2 event if revenue is being logged', function() {
+        amplitude.options.useLogRevenueV2 = true;
+        analytics.track('event', { price: 10.00, quantity: 2, productId: 'AMP1' });
+        analytics.called(window.amplitude.logEvent);
+        analytics.didNotCall(window.amplitude.logRevenue);
+        analytics.didNotCall(window.amplitude.logRevenueV2);
+      });
     });
 
     describe('#group', function() {


### PR DESCRIPTION
Similar to https://github.com/segment-integrations/integration-amplitude/pull/20, we need to fix a bug introduced with this merge: https://github.com/segment-integrations/analytics.js-integration-amplitude/pull/19.

Basically there are cases when customers want to track price as a property, without intending to track it as revenue. We should only explicitly pull the price when the event has revenue.

@f2prateek if you could release this ASAP that would be greatly appreciated. Thanks! (I will submit PR for iOS and Android shortly after this)
