### PR TITLE
flatten any arrays

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,9 @@ var bind = require('component-bind');
 var integration = require('@segment/analytics.js-integration');
 var topDomain = require('@segment/top-domain');
 var when = require('do-when');
+var each = require('@ndhoule/each');
+var trample = require('@segment/trample');
+var extend = require('@ndhoule/extend');
 
 /**
  * UMD?
@@ -147,9 +150,9 @@ Amplitude.prototype.identify = function(identify) {
 Amplitude.prototype.track = function(track) {
   var props = track.properties();
   var event = track.event();
-
+  
   // track the event
-  window.amplitude.logEvent(event, props);
+  window.amplitude.logEvent(event, flattenArrays(props));
 
   // also track revenue
   var revenue = track.revenue();
@@ -213,3 +216,38 @@ Amplitude.prototype.setDomain = function(href) {
 Amplitude.prototype.setDeviceId = function(deviceId) {
   if (deviceId) window.amplitude.setDeviceId(deviceId);
 };
+
+/**
+ * Flatten arrays with nested objects or arrays
+ * @api private
+ * @param {Object} properties
+ * @return {Object} ret
+ */
+
+function flattenArrays(properties) {
+  // Amplitude does not accept any elements inside arrays that are arrays or objects
+  var ret = {};
+  each(function(value, key) {
+    if (isArray(value)) {
+      var flattened = {};
+      flattened[key] = value;
+      flattened = trample(flattened);
+      ret = extend(ret, flattened);
+    } else {
+      ret[key] = value;
+    }
+  }, properties);
+  return ret;
+}
+
+/**
+ * Check if value is an array
+ *
+ * @api private
+ * @param {Array} array
+ * @return {Boolean} boolean
+ */
+
+function isArray(array) {
+  return array.constructor === Array;
+}

--- a/package.json
+++ b/package.json
@@ -23,8 +23,11 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-amplitude#readme",
   "dependencies": {
+    "@ndhoule/each": "^2.0.1",
+    "@ndhoule/extend": "^2.0.0",
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/top-domain": "^3.0.0",
+    "@segment/trample": "^0.1.0",
     "component-bind": "^1.0.0",
     "do-when": "^1.0.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -263,6 +263,59 @@ describe('Amplitude', function() {
         analytics.didNotCall(window.amplitude.logRevenue);
         analytics.didNotCall(window.amplitude.logRevenueV2);
       });
+
+      it('should flatten arrays that have nested arrays or objects', function() {
+        analytics.track('Order Completed', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        }); 
+        analytics.called(window.amplitude.logEvent, 'Order Completed', { 
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          'products.0.id': '507f1f77bcf86cd799439011',
+          'products.0.sku': '45790-32',
+          'products.0.name': 'Monopoly: 3rd Edition',
+          'products.0.price': 19,
+          'products.0.quantity': 1,
+          'products.0.category': 'Games',
+          'products.1.id': '505bd76785ebb509fc183733',
+          'products.1.sku': '46493-32',
+          'products.1.name': 'Uno Card Game',
+          'products.1.price': 3,
+          'products.1.quantity': 2,
+          'products.1.category': 'Games'
+        });
+      });
     });
 
     describe('#group', function() {


### PR DESCRIPTION
@djih @ladanazita @f2prateek 

This resolves: https://segment.atlassian.net/browse/INT-648

**Issue**: any arrays that contain objects or arrays have been getting dropped by the Amplitude library, meaning that customers using our [ecommerce spec v1/v2](https://segment.com/docs/spec/ecommerce/v2/#order-completed) weren't able to get any product information in Amplitude. The `products` property is an array that contains objects for each product.

**solution**: for any property that is an array, we're simply going to flatten it. I do not believe this will break reports for anyone since any arrays that contained compound objects were completely skipped anyway. 

@djih can you confirm if this behavior looks okay to you guys in terms of customer impact?

```
it('should flatten arrays that have nested arrays or objects', function() {
          // Segment analytics.js call
+        analytics.track('Order Completed', {
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        }); 

          // What we would call using Amplitude API
+        analytics.called(window.amplitude.logEvent, 'Order Completed', { 
+          order_id: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          'products.0.id': '507f1f77bcf86cd799439011',
+          'products.0.sku': '45790-32',
+          'products.0.name': 'Monopoly: 3rd Edition',
+          'products.0.price': 19,
+          'products.0.quantity': 1,
+          'products.0.category': 'Games',
+          'products.1.id': '505bd76785ebb509fc183733',
+          'products.1.sku': '46493-32',
+          'products.1.name': 'Uno Card Game',
+          'products.1.price': 3,
+          'products.1.quantity': 2,
+          'products.1.category': 'Games'
+        });
+      });
```

Note how we would translate the `products` array.
- [ ] update docs

Also @djih does your HTTP API also not accept arrays with compound objects? If so we should also open a PR for the server side integration to do the same flattening logic as seen here.
