### PR TITLE
update amplitude JS SDK v3.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.2.0 / 2016-11-15
+==================
+
+  * Update Amplitude v3.4.0 with support for forceHttps, trackGclid, saveParamsReferrerOncePerSession, deviceIdFromUrlParam options.
+
 2.1.1 / 2016-08-08
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var umd = typeof window.define === 'function' && window.define.amd;
  * Source.
  */
 
-var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-3.0.2-min.gz.js';
+var src = '//d24n15hnbwhuhn.cloudfront.net/libs/amplitude-3.4.0-min.gz.js';
 
 /**
  * Expose `Amplitude` integration.
@@ -37,6 +37,10 @@ var Amplitude = module.exports = integration('Amplitude')
   .option('eventUploadThreshold', 30)
   .option('eventUploadPeriodMillis', 30000)
   .option('useLogRevenueV2', false)
+  .option('forceHttps', false)
+  .option('trackGclid', false)
+  .option('saveParamsReferrerOncePerSession', true)
+  .option('deviceIdFromUrlParam', false)
   .tag('<script src="' + src + '">');
 
 /**
@@ -58,7 +62,11 @@ Amplitude.prototype.initialize = function() {
     includeReferrer: this.options.trackReferrer,
     batchEvents: this.options.batchEvents,
     eventUploadThreshold: this.options.eventUploadThreshold,
-    eventUploadPeriodMillis: this.options.eventUploadPeriodMillis
+    eventUploadPeriodMillis: this.options.eventUploadPeriodMillis,
+    forceHttps: this.options.forceHttps,
+    includeGclid: this.options.trackGclid,
+    saveParamsReferrerOncePerSession: this.options.saveParamsReferrerOncePerSession,
+    deviceIdFromUrlParam: this.options.deviceIdFromUrlParam
   });
 
   var loaded = bind(this, this.loaded);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,7 +15,11 @@ describe('Amplitude', function() {
     trackReferrer: false,
     batchEvents: false,
     eventUploadThreshold: 30,
-    eventUploadPeriodMillis: 30000
+    eventUploadPeriodMillis: 30000,
+    forceHttps: false,
+    trackGclid: false,
+    saveParamsReferrerOncePerSession: true,
+    deviceIdFromUrlParam: false
   };
 
   beforeEach(function() {
@@ -43,7 +47,11 @@ describe('Amplitude', function() {
       .option('trackReferrer', false)
       .option('batchEvents', false)
       .option('eventUploadThreshold', 30)
-      .option('eventUploadPeriodMillis', 30000));
+      .option('eventUploadPeriodMillis', 30000)
+      .option('forceHttps', false)
+      .option('trackGclid', false)
+      .option('saveParamsReferrerOncePerSession', true)
+      .option('deviceIdFromUrlParam', false));
   });
 
   describe('before loading', function() {
@@ -89,6 +97,10 @@ describe('Amplitude', function() {
       analytics.assert(window.amplitude.options.batchEvents === options.batchEvents);
       analytics.assert(window.amplitude.options.eventUploadThreshold === options.eventUploadThreshold);
       analytics.assert(window.amplitude.options.eventUploadPeriodMillis === options.eventUploadPeriodMillis);
+      analytics.assert(window.amplitude.options.forceHttps === options.forceHttps);
+      analytics.assert(window.amplitude.options.includeGclid === options.trackGclid);
+      analytics.assert(window.amplitude.options.saveParamsReferrerOncePerSession === options.saveParamsReferrerOncePerSession);
+      analytics.assert(window.amplitude.options.deviceIdFromUrlParam === options.deviceIdFromUrlParam);
     });
 
     it('should set api key', function() {


### PR DESCRIPTION
Updating SDK to version 3.4.0, with bug fixes and some new configuration options: [Changelog](https://github.com/amplitude/Amplitude-Javascript/blob/master/CHANGELOG.md).

We want to add:
* The ability to force event uploads to use HTTPS
* The ability to parse and track Google Click Ids from url params (similar to how we already parse and track utm params)
* The ability to track params and referrers more than once per session. Our [Readme](https://github.com/amplitude/Amplitude-Javascript#tracking-utm-parameters-referrer-and-gclid) clarifies what this means
* The ability to initialize the SDK with a device id from a url parameter. This was a customer request. If this option is enabled, then the SDK will look for an `amp_device_id` url parameter and set the device id to whatever that value is.

Here is the JSON writeups for each option:
```
"forceHttps": {
   "default": false,
   "description": "If true, the events will always be uploaded to HTTPS endpoint. Otherwise the SDK will use the embedding site's protocol.",
   "label": "Force Https",
   "type": "boolean"
}

"trackGclid": {
   "default": false,
   "description": "If true, captures the gclid url parameter as well as the user's initial_gclid via a set once operation.",
   "label": "Track GCLID",
   "type": "boolean"
}

"saveParamsReferrerOncePerSession": {
   "default": true,
   "description": "If true then includeGclid, includeReferrer, and includeUtm will only track their respective properties once per session. New values that come in during the middle of the user's session will be ignored. Set to false to always capture new values.",
   "label": "Save Referrer, URL Params, GCLID Once Per Session",
   "type": "boolean"
}

"deviceIdFromUrlParam": {
   "default": false,
   "description": "If true, the SDK will parse device ID values from url parameter `amp_device_id` if available.",
   "label": "Set Device ID From URL Parameter amp_device_id",
   "type": "boolean"
}
```
