### PR TITLE
Added deviceIdFromUrlParam to configuration options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,7 @@ Amplitude.prototype.initialize = function() {
   window.amplitude.init(this.options.apiKey, null, {
     includeUtm: this.options.trackUtmProperties,
     includeReferrer: this.options.trackReferrer,
+    deviceIdFromUrlParam: true,
     batchEvents: this.options.batchEvents,
     eventUploadThreshold: this.options.eventUploadThreshold,
     eventUploadPeriodMillis: this.options.eventUploadPeriodMillis


### PR DESCRIPTION
Set new configuration option: deviceIdFromUrlParam to true -- If true, the SDK will parse device ID values from url parameter amp_device_id if available. Device IDs defined in the configuration options during init will take priority over device IDs from url parameters. -- Which should only impact users who that include the url parameter.