### PR TITLE
Unit test for deviceIdFromUrlParam config option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,7 @@ Amplitude.prototype.initialize = function() {
   window.amplitude.init(this.options.apiKey, null, {
     includeUtm: this.options.trackUtmProperties,
     includeReferrer: this.options.trackReferrer,
+    deviceIdFromUrlParam: true,
     batchEvents: this.options.batchEvents,
     eventUploadThreshold: this.options.eventUploadThreshold,
     eventUploadPeriodMillis: this.options.eventUploadPeriodMillis

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,7 +86,8 @@ describe('Amplitude', function() {
     it('should init with right options', function() {
       analytics.assert(window.amplitude.options.includeUtm === options.trackUtmProperties);
       analytics.assert(window.amplitude.options.includeReferrer === options.trackReferrer);
-      analytics.assert(window.amplitude.options.batchEvents === options.batchEvents);
+      analytics.assert(window.amplitude.options.deviceIdFromUrlParam === true);
+      analytics.assert(window.amplitude.options.batchEvents === options.batchEvents); 
       analytics.assert(window.amplitude.options.eventUploadThreshold === options.eventUploadThreshold);
       analytics.assert(window.amplitude.options.eventUploadPeriodMillis === options.eventUploadPeriodMillis);
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,6 +14,7 @@ describe('Amplitude', function() {
     trackUtmProperties: true,
     trackReferrer: false,
     batchEvents: false,
+    deviceIdFromUrlParam: true,
     eventUploadThreshold: 30,
     eventUploadPeriodMillis: 30000
   };
@@ -86,7 +87,7 @@ describe('Amplitude', function() {
     it('should init with right options', function() {
       analytics.assert(window.amplitude.options.includeUtm === options.trackUtmProperties);
       analytics.assert(window.amplitude.options.includeReferrer === options.trackReferrer);
-      analytics.assert(window.amplitude.options.deviceIdFromUrlParam === true);
+      analytics.assert(window.amplitude.options.deviceIdFromUrlParam === options.deviceIdFromUrlParam);
       analytics.assert(window.amplitude.options.batchEvents === options.batchEvents); 
       analytics.assert(window.amplitude.options.eventUploadThreshold === options.eventUploadThreshold);
       analytics.assert(window.amplitude.options.eventUploadPeriodMillis === options.eventUploadPeriodMillis);


### PR DESCRIPTION
Added unit test for deviceIdFromUrlParam to analytics.assert only since it is not a selectable option in the Amplitude settings and forced set to 'true'