### PR TITLE
remove logrevenuev2, add $revenue, $productId and $revenueType

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,37 +154,19 @@ Amplitude.prototype.identify = function(identify) {
 
 Amplitude.prototype.track = function(track) {
   var props = track.properties();
+  var revenue = track.revenue();
+  var productId = track.productId();
+  var revenueType = props.revenueType;
   var event = track.event();
+
+  // For parity reasons
+  if (revenue) props.$revenue = revenue;
+  // For legacy reasons
+  if (productId) props.$productId = productId;
+  if (revenueType) props.$revenueType = revenueType;
 
   // track the event
   window.amplitude.logEvent(event, props);
-
-  // also track revenue
-  var revenue = track.revenue();
-  if (revenue) {
-    // use logRevenueV2 with revenue props
-    if (this.options.useLogRevenueV2) {
-      var price = props.price;
-      var quantity = props.quantity;
-      if (!price) {
-        price = revenue;
-        quantity = 1;
-      }
-
-      var ampRevenue = new window.amplitude.Revenue().setPrice(price).setQuantity(quantity);
-      if (props.productId) {
-        ampRevenue.setProductId(props.productId);
-      }
-      if (props.revenueType) {
-        ampRevenue.setRevenueType(props.revenueType);
-      }
-      ampRevenue.setEventProperties(props);
-      window.amplitude.logRevenueV2(ampRevenue);
-    } else {
-      // fallback to logRevenue v1
-      window.amplitude.logRevenue(revenue, props.quantity, props.productId);
-    }
-  }
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -222,58 +222,20 @@ describe('Amplitude', function() {
         analytics.didNotCall(window.amplitude.logRevenueV2);
       });
 
-      it('should send a revenue event', function() {
-        analytics.track('event', { revenue: 19.99 });
-        analytics.called(window.amplitude.logRevenue, 19.99, undefined, undefined);
-        analytics.didNotCall(window.amplitude.logRevenueV2);
+      it('should also add $revenue if properties.revenue exists', function() {
+        analytics.track('event', { revenue: 17.38 });
+        analytics.called(window.amplitude.logEvent, 'event', { revenue: 17.38, $revenue: 17.38 });
       });
 
-      it('should send a revenue event with quantity and productId', function() {
-        analytics.track('event', { revenue: 19.99, quantity: 2, productId: 'AMP1' });
-        analytics.called(window.amplitude.logRevenue, 19.99, 2, 'AMP1');
-        analytics.didNotCall(window.amplitude.logRevenueV2);
+      // FIXME: revisit this behavior later because it does not comply very well with our ecommerce spec
+      it('should also add $productId if productId if properties.productId exists', function() {
+        analytics.track('event', { product_id: 'yolo123' });
+        analytics.called(window.amplitude.logEvent, 'event', { product_id: 'yolo123', $productId: 'yolo123' });
       });
 
-      it('should send a revenueV2 event', function() {
-        amplitude.options.useLogRevenueV2 = true;
-        analytics.track('event', { revenue: 19.99 });
-        var ampRevenue = new window.amplitude.Revenue().setPrice(19.99).setEventProperties({ revenue: 19.99 });
-        analytics.didNotCall(window.amplitude.logRevenue);
-        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
-      });
-
-      it('should send a revenueV2 event with quantity and productId and revenueType', function() {
-        amplitude.options.useLogRevenueV2 = true;
-        var props = { revenue: 20.00, quantity: 2, price: 10.00, productId: 'AMP1', revenueType: 'purchase' };
-        analytics.track('event', props);
-        var ampRevenue = new window.amplitude.Revenue().setPrice(10.00).setQuantity(2).setProductId('AMP1');
-        ampRevenue.setRevenueType('purchase').setEventProperties(props);
-        analytics.didNotCall(window.amplitude.logRevenue);
-        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
-      });
-
-      it('should send a revenueV2 event with revenue if missing price', function() {
-        amplitude.options.useLogRevenueV2 = true;
-        analytics.track('event', { revenue: 20.00, quantity: 2, productId: 'AMP1' });
-        var ampRevenue = new window.amplitude.Revenue().setPrice(20.00).setProductId('AMP1');
-        ampRevenue.setEventProperties({ revenue: 20.00, quantity: 2, productId: 'AMP1' });
-        analytics.didNotCall(window.amplitude.logRevenue);
-        analytics.called(window.amplitude.logRevenueV2, ampRevenue);
-      });
-
-      it('should only send a revenue event if revenue is being logged', function() {
-        analytics.track('event', { price: 10.00, quantity: 2, productId: 'AMP1' });
-        analytics.called(window.amplitude.logEvent);
-        analytics.didNotCall(window.amplitude.logRevenue);
-        analytics.didNotCall(window.amplitude.logRevenueV2);
-      });
-
-      it('should only send a revenueV2 event if revenue is being logged', function() {
-        amplitude.options.useLogRevenueV2 = true;
-        analytics.track('event', { price: 10.00, quantity: 2, productId: 'AMP1' });
-        analytics.called(window.amplitude.logEvent);
-        analytics.didNotCall(window.amplitude.logRevenue);
-        analytics.didNotCall(window.amplitude.logRevenueV2);
+      it('should also add $revenueType if properties.revenueType exists', function() {
+        analytics.track('event', { revenueType: 'refund' });
+        analytics.called(window.amplitude.logEvent, 'event', { revenueType: 'refund', $revenueType: 'refund' });
       });
     });
 


### PR DESCRIPTION
I had a call with @djih and William from Amplitude in regards to the lack of parity between our server side and client side Amplitude in regards to how we handle `revenue`. 

The `logRevenue` and `logRevenueV2` is primarily meant to verify revenue receipts with Apple (Amplitude mobile SDK does this). This is more or less unnecessary on javascript.. The proposed changes of adding `$revenue`, `$productId`, and `$revenueType` will cover the current behavior at least when it comes to users building reports. So this PR does not really have "breaking" impact as far as reporting goes.

We are _not_ removing the duplicative `revenue` here for legacy reasons since some might still be pegging their reports on that. 

- [ ] get [server side PR](https://github.com/segment-integrations/integration-amplitude/pull/33) merged
- [ ] site-docs
- [ ] deploy

@tsholmes 