### PR TITLE
Query params EPD-2483

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.3.0 / 2017-04-11
+==================
+
+  * Allow mapping query params from context.page.search to a custom user/event property
+
 2.2.0 / 2016-11-15
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ var bind = require('component-bind');
 var integration = require('@segment/analytics.js-integration');
 var topDomain = require('@segment/top-domain');
 var when = require('do-when');
+var is = require('is');
+var each = require('@ndhoule/each');
 
 /**
  * UMD?
@@ -41,6 +43,7 @@ var Amplitude = module.exports = integration('Amplitude')
   .option('trackGclid', false)
   .option('saveParamsReferrerOncePerSession', true)
   .option('deviceIdFromUrlParam', false)
+  .option('mapQueryParams', {})
   .tag('<script src="' + src + '">');
 
 /**
@@ -142,7 +145,20 @@ Amplitude.prototype.identify = function(identify) {
   var id = identify.userId();
   var traits = identify.traits();
   if (id) window.amplitude.setUserId(id);
-  if (traits) window.amplitude.setUserProperties(traits);
+  if (traits) {
+    // map query params from context url if opted in
+    var mapQueryParams = this.options.mapQueryParams;
+    var query = identify.proxy('context.page.search');
+    if (!is.empty(mapQueryParams)) {
+      // since we accept any arbitrary property name and we dont have conditional UI components
+      // in the app where we can limit users to only add a single mapping, so excuse the temporary jank
+      each(function(value, key) {
+        traits[key] = query;
+      }, mapQueryParams);
+    }
+
+    window.amplitude.setUserProperties(traits);
+  }
 };
 
 /**
@@ -155,6 +171,22 @@ Amplitude.prototype.identify = function(identify) {
 Amplitude.prototype.track = function(track) {
   var props = track.properties();
   var event = track.event();
+  // map query params from context url if opted in
+  var mapQueryParams = this.options.mapQueryParams;
+  var query = track.proxy('context.page.search');
+  if (!is.empty(mapQueryParams)) {
+    var params = {};
+    var type;
+      // since we accept any arbitrary property name and we dont have conditional UI components
+      // in the app where we can limit users to only add a single mapping, so excuse the temporary jank
+    each(function(value, key) {
+      // add query params to either `user_properties` or `event_properties`
+      type = value;
+      type === 'user_properties' ? params[key] = query : props[key] = query;
+    }, mapQueryParams);
+
+    if (type === 'user_properties') window.amplitude.setUserProperties(params);
+  }
 
   // track the event
   window.amplitude.logEvent(event, props);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/top-domain": "^3.0.0",
     "component-bind": "^1.0.0",
-    "do-when": "^1.0.0"
+    "do-when": "^1.0.0",
+    "is": "^3.2.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/segment-integrations/analytics.js-integration-amplitude#readme",
   "dependencies": {
+    "@ndhoule/each": "^2.0.1",
     "@segment/analytics.js-integration": "^2.1.0",
     "@segment/top-domain": "^3.0.0",
     "component-bind": "^1.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -189,11 +189,11 @@ describe('Amplitude', function() {
       it('should map query params to custom property as event properties', function() {
         amplitude.options.trackAllPages = true;
         amplitude.options.mapQueryParams = { params: 'event_properties' };
-        analytics.page({}, { page: { search: '?suh=dude' } });
+        analytics.page({ referrer: document.referrer }, { page: { search: '?suh=dude' } });
         analytics.called(window.amplitude.logEvent, 'Loaded a Page', {
           params: '?suh=dude',
           path: '/context.html',
-          referrer: 'http://localhost:9876/?id=49847017',
+          referrer: document.referrer,
           search: '', // in practice this would also be set to the query param but limitation of test prevents this from being set
           title: '',
           url: 'http://localhost:9876/context.html'


### PR DESCRIPTION
This is the client side PR for https://github.com/segment-integrations/integration-amplitude/pull/45

let's you map the query params collected in context.page.search to be sent as a custom user/event prop of your choice.

already deployed on server side and migration/metadata updated. just need to deploy

this is also backwards compat

@tsholmes @segment-integrations/integrations