### PR TITLE
Identify and track with groups

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,9 @@
 
+2.4.0 / 2017-05-17
+==================
+
+  * Add support for Amplitude's `group` functionality to both identify and track events
+
 2.3.0 / 2017-04-11
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,6 +178,7 @@ Amplitude.prototype.identify = function(identify) {
 
 Amplitude.prototype.track = function(track) {
   var props = track.properties();
+  var options = track.options(this.name);
   var event = track.event();
   // map query params from context url if opted in
   var mapQueryParams = this.options.mapQueryParams;
@@ -224,6 +225,10 @@ Amplitude.prototype.track = function(track) {
       // fallback to logRevenue v1
       window.amplitude.logRevenue(revenue, props.quantity, props.productId);
     }
+  }
+
+  if (options.groups) {
+    window.amplitude.logEventWithGroups(event, props, options.groups);
   }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,7 +162,7 @@ Amplitude.prototype.identify = function(identify) {
 
   // Set user groups: https://amplitude.zendesk.com/hc/en-us/articles/115001361248#setting-user-groups
   var groups = identify.options(this.name).groups;
-  if (groups) {
+  if (groups && is.object(groups)) {
     for (var group in groups) {
       if (groups.hasOwnProperty(group)) window.amplitude.setGroup(group, groups[group]);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -159,6 +159,14 @@ Amplitude.prototype.identify = function(identify) {
 
     window.amplitude.setUserProperties(traits);
   }
+
+  // Set user groups: https://amplitude.zendesk.com/hc/en-us/articles/115001361248#setting-user-groups
+  var groups = identify.options(this.name).groups;
+  if (groups) {
+    for (var group in groups) {
+      if (groups.hasOwnProperty(group)) window.amplitude.setGroup(group, groups[group]);
+    }
+  }
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-amplitude",
   "description": "The Amplitude analytics.js integration.",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -243,6 +243,7 @@ describe('Amplitude', function() {
         analytics.stub(window.amplitude, 'setUserProperties');
         analytics.stub(window.amplitude, 'logRevenue');
         analytics.stub(window.amplitude, 'logRevenueV2');
+        analytics.stub(window.amplitude, 'logEventWithGroups');
       });
 
       it('should send an event', function() {
@@ -323,6 +324,11 @@ describe('Amplitude', function() {
         amplitude.options.mapQueryParams = { ham: 'event_properties' };
         analytics.track('event', { foo: 'bar' }, { page: { search: '?foo=bar' } });
         analytics.called(window.amplitude.logEvent, 'event', { foo: 'bar', ham: '?foo=bar' });
+      });
+
+      it('should send an event with groups if `groups` is an integration specific option', function() {
+        analytics.track('event', { foo: 'bar' }, { integrations: { Amplitude: { groups: { sports: 'basketball' } } } });
+        analytics.called(window.amplitude.logEventWithGroups, 'event', { foo: 'bar' }, { sports: 'basketball' });
       });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -205,6 +205,7 @@ describe('Amplitude', function() {
       beforeEach(function() {
         analytics.stub(window.amplitude, 'setUserId');
         analytics.stub(window.amplitude, 'setUserProperties');
+        analytics.stub(window.amplitude, 'setGroup');
       });
 
       it('should send an id', function() {
@@ -228,6 +229,11 @@ describe('Amplitude', function() {
         analytics.identify('id', { trait: true }, { page: { search: '?foo=bar' } });
         analytics.called(window.amplitude.setUserId, 'id');
         analytics.called(window.amplitude.setUserProperties, { id: 'id', trait: true, ham: '?foo=bar' });
+      });
+
+      it('should set user groups if integration option `groups` is present', function() {
+        analytics.identify('id', {}, { integrations: { Amplitude: { groups: { foo: 'bar' } } } });
+        analytics.called(window.amplitude.setGroup, 'foo', 'bar');
       });
     });
 


### PR DESCRIPTION
PR adds support for Amplitude's group functionality.

Amplitude's JS API has a method called `setGroup` that allows for assigning users to specific groupTypes/groupNames: https://amplitude.zendesk.com/hc/en-us/articles/115001361248#setting-user-groups

We are going to integrate with this via our `identify` method as the Amplitude groups functionality is more akin to tags than companies as our `group` method is.

Users can be assigned to multiple groups so we are allowing for an object to be passed as an integration specific option and will loop through it invoking `setGroup` for each key/value pair.

Groups can also be a part of events via a method called `logEventWithGroups`. Therefore we have also added support for passing this integration specific groups option to track events.

We're keeping our older group method for backwards compatibility but will be recommending that users use this new way of leveraging this functionality.