### PR TITLE
Modify Group API to accept groupType from traits

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -256,7 +256,9 @@ Amplitude.prototype.orderCompleted = function(track) {
 
 Amplitude.prototype.group = function(group) {
   var groupId = group.groupId();
-  if (groupId) window.amplitude.setGroup('[Segment] Group', groupId);
+
+  // For advanced reporting, some customers will send a groupType in their properties or traits. Use that if it exists, otherwise default to the old version.
+  if (groupId) window.amplitude.setGroup(group.traits().groupType || '[Segment] Group', groupId);
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -398,6 +398,11 @@ describe('Amplitude', function() {
         analytics.group('testGroupId');
         analytics.called(window.amplitude.setGroup, '[Segment] Group', 'testGroupId');
       });
+
+      it('should use groupType from traits', function() {
+        analytics.group('testGroupId', { groupType: 'testGroupType' });
+        analytics.called(window.amplitude.setGroup, 'testGroupType', 'testGroupId');
+      });
     });
   });
 });


### PR DESCRIPTION
This adds the ability for users to explicitly set a groupType in Amplitude. If this setting isn't set, we will default to the old type.