### PR TITLE
anonymousID-as-deviceID + group{Type, Value}Trait support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -265,6 +265,17 @@ Amplitude.prototype.orderCompleted = function(track) {
 
 Amplitude.prototype.group = function(group) {
   this.setDeviceIdFromAnonymousId(group);
+
+  var groupType = group.traits()[this.options.groupTypeTrait];
+  var groupValue = group.traits()[this.options.groupValueTrait];
+  if (groupType && groupValue) {
+    window.amplitude.setGroup(groupType, groupValue);
+  } else {
+    var groupId = group.groupId();
+    if (groupId) {
+      window.amplitude.setGroup('[Segment] Group', groupId);
+    }
+  }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,7 @@ var Amplitude = module.exports = integration('Amplitude')
   .option('deviceIdFromUrlParam', false)
   .option('mapQueryParams', {})
   .option('trackRevenuePerProduct', false)
+  .option('preferAnonymousIdForDeviceId', false)
   .tag('<script src="' + src + '">');
 
 /**
@@ -116,6 +117,8 @@ Amplitude.prototype.loaded = function() {
  */
 
 Amplitude.prototype.page = function(page) {
+  this.setDeviceIdFromAnonymousId(page);
+
   var category = page.category();
   var name = page.fullName();
   var opts = this.options;
@@ -144,6 +147,8 @@ Amplitude.prototype.page = function(page) {
  */
 
 Amplitude.prototype.identify = function(identify) {
+  this.setDeviceIdFromAnonymousId(identify);
+
   var id = identify.userId();
   var traits = identify.traits();
   if (id) window.amplitude.setUserId(id);
@@ -181,6 +186,8 @@ Amplitude.prototype.identify = function(identify) {
 Amplitude.prototype.track = logEvent;
 
 function logEvent(track, dontSetRevenue) {
+  this.setDeviceIdFromAnonymousId(track);
+
   var props = track.properties();
   var options = track.options(this.name);
   var event = track.event();
@@ -215,6 +222,8 @@ function logEvent(track, dontSetRevenue) {
 }
 
 Amplitude.prototype.orderCompleted = function(track) {
+  this.setDeviceIdFromAnonymousId(track);
+
   var products = track.products();
   var clonedTrack = track.json();
   var trackRevenuePerProduct = this.options.trackRevenuePerProduct;
@@ -255,8 +264,7 @@ Amplitude.prototype.orderCompleted = function(track) {
  */
 
 Amplitude.prototype.group = function(group) {
-  var groupId = group.groupId();
-  if (groupId) window.amplitude.setGroup('[Segment] Group', groupId);
+  this.setDeviceIdFromAnonymousId(group);
 };
 
 /**
@@ -272,6 +280,22 @@ Amplitude.prototype.setDomain = function(href) {
 };
 
 /**
+ * If enabled by settings, set the device ID from the Segment anonymous ID.
+ *
+ * This logic cannot be performed at initialization time, because customers may
+ * want to modify anonymous IDs between initializing Segment and sending their
+ * first event.
+ *
+ * @api private
+ * @param {Fadade} facade to get anonymousId from.
+ */
+Amplitude.prototype.setDeviceIdFromAnonymousId = function(facade) {
+  if (this.options.preferAnonymousIdForDeviceId) {
+    this.setDeviceId(facade.anonymousId());
+  }
+};
+
+/**
  * Override device ID in Amplitude.
  *
  * @api private
@@ -281,7 +305,6 @@ Amplitude.prototype.setDomain = function(href) {
 Amplitude.prototype.setDeviceId = function(deviceId) {
   if (deviceId) window.amplitude.setDeviceId(deviceId);
 };
-
 
 Amplitude.prototype.setRevenue = function(properties) {
   var price = properties.price;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -451,6 +451,20 @@ describe('Amplitude', function() {
         analytics.called(window.amplitude.setGroup, '[Segment] Group', 'testGroupId');
       });
 
+      it('should use `groupTypeTrait` and `groupValueTrait` when both are present', function() {
+        amplitude.options.groupTypeTrait = 'foo';
+        amplitude.options.groupValueTrait = 'bar';
+        analytics.group('testGroupId', { foo: 'asdf', bar: 'fafa' });
+        analytics.called(window.amplitude.setGroup, 'asdf', 'fafa');
+      });
+
+      it('should fall back to default behavior if either `group{Type, Value}Trait` is missing', function() {
+        amplitude.options.groupTypeTrait = 'foo';
+        amplitude.options.groupValueTrait = 'bar';
+        analytics.group('testGroupId', { notFoo: 'asdf', bar: 'fafa' });
+        analytics.called(window.amplitude.setGroup, '[Segment] Group', 'testGroupId');
+      });
+
       it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
         analytics.user().anonymousId('example');
         amplitude.options.preferAnonymousIdForDeviceId = false;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -147,6 +147,7 @@ describe('Amplitude', function() {
       beforeEach(function() {
         analytics.stub(window.amplitude, 'logEvent');
         analytics.stub(window.amplitude, 'setUserProperties');
+        analytics.stub(window.amplitude, 'setDeviceId');
       });
 
       it('should not track unnamed pages by default', function() {
@@ -202,6 +203,17 @@ describe('Amplitude', function() {
           url: 'http://localhost:9876/context.html'
         });
       });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.identify('id');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.identify('id');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
     });
 
     describe('#identify', function() {
@@ -209,6 +221,7 @@ describe('Amplitude', function() {
         analytics.stub(window.amplitude, 'setUserId');
         analytics.stub(window.amplitude, 'setUserProperties');
         analytics.stub(window.amplitude, 'setGroup');
+        analytics.stub(window.amplitude, 'setDeviceId');
       });
 
       it('should send an id', function() {
@@ -238,6 +251,17 @@ describe('Amplitude', function() {
         analytics.identify('id', {}, { integrations: { Amplitude: { groups: { foo: 'bar' } } } });
         analytics.called(window.amplitude.setGroup, 'foo', 'bar');
       });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.identify('id');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.identify('id');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
     });
 
     describe('#track', function() {
@@ -247,6 +271,7 @@ describe('Amplitude', function() {
         analytics.stub(window.amplitude, 'logRevenue');
         analytics.stub(window.amplitude, 'logRevenueV2');
         analytics.stub(window.amplitude, 'logEventWithGroups');
+        analytics.stub(window.amplitude, 'setDeviceId');
       });
 
       it('should send an event', function() {
@@ -333,9 +358,24 @@ describe('Amplitude', function() {
         analytics.track('event', { foo: 'bar' }, { integrations: { Amplitude: { groups: { sports: 'basketball' } } } });
         analytics.called(window.amplitude.logEventWithGroups, 'event', { foo: 'bar' }, { sports: 'basketball' });
       });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.page();
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.page();
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
     });
 
     describe('#orderCompleted', function() {
+      beforeEach(function() {
+        analytics.stub(window.amplitude, 'setDeviceId');
+      });
+
       var payload;
       beforeEach(function() {
         payload = {
@@ -387,16 +427,39 @@ describe('Amplitude', function() {
         analytics.track('Order Completed', payload);
         analytics.assert(spy.withArgs('Product Purchased').calledTwice);
       });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.track('Order Completed');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.track('Order Completed');
+        analytics.called(window.amplitude.setDeviceId, 'example');
+      });
     });
 
     describe('#group', function() {
       beforeEach(function() {
         analytics.stub(window.amplitude, 'setGroup');
+        analytics.stub(window.amplitude, 'setDeviceId');
       });
 
       it('should call setGroup', function() {
         analytics.group('testGroupId');
         analytics.called(window.amplitude.setGroup, '[Segment] Group', 'testGroupId');
+      });
+
+      it('should set deviceId if `preferAnonymousIdForDeviceId` is set', function() {
+        analytics.user().anonymousId('example');
+        amplitude.options.preferAnonymousIdForDeviceId = false;
+        analytics.group('group');
+        analytics.didNotCall(window.amplitude.setDeviceId);
+
+        amplitude.options.preferAnonymousIdForDeviceId = true;
+        analytics.group('group');
+        analytics.called(window.amplitude.setDeviceId, 'example');
       });
     });
   });


### PR DESCRIPTION
* Adds support for using the Segment anonymousId as the Amplitude deviceID.

* Adds support for the `groupTypeTrait` and `groupValueTrait` Segment settings, which make Amplitude groups much more useful. These are already supported on all other platforms.